### PR TITLE
Support new filename for `migrate` binary

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -31,7 +31,7 @@ install() {
   echo "Downloading migrate from ${download_url}"
   curl -sSL "$download_url" -o "${tmp_download_dir}/gomigrate.tar.gz"
   tar -xzf "${tmp_download_dir}/gomigrate.tar.gz" -C "${bin_install_path}"
-  mv "${bin_install_path}/migrate.${platform}-${arch}" "${bin_install_path}/migrate"
+  [ -f "${bin_install_path}/migrate.${platform}-${arch}" ] && mv "${bin_install_path}/migrate.${platform}-${arch}" "${bin_install_path}/migrate"
   rm -f "${tmp_download_dir}/gomigrate.tar.gz"
 }
 


### PR DESCRIPTION
The executable's filename inside the tar-ball seems to have changed in golang-migrate 4.15.0.

```
# curl -OL https://github.com/golang-migrate/migrate/releases/download/v4.14.1/migrate.linux-amd64.tar.gz
# tar tfzv migrate.linux-amd64.tar.gz
-rwxrwxr-x travis/travis 39825487 2020-11-22 06:09 ./migrate.linux-amd64
# curl -OL https://github.com/golang-migrate/migrate/releases/download/v4.15.0/migrate.linux-amd64.tar.gz
# tar tfzv migrate.linux-amd64.tar.gz
-rw-r--r-- runner/docker  1219 2021-09-22 09:06 LICENSE
-rw-r--r-- runner/docker  7723 2021-09-22 09:06 README.md
-rwxr-xr-x runner/docker 31076352 2021-09-22 09:11 migrate
```

Closes #1